### PR TITLE
Fix JS errors not preventing form submit

### DIFF
--- a/Forms Module/core/workflow.js
+++ b/Forms Module/core/workflow.js
@@ -74,6 +74,7 @@ Forms.evalSubmit = function (form) {
 
     if (returnValue != undefined && returnValue != 0 && returnValue != 1 && returnValue != 2) {
         App.alert("Javascript Error: " + returnValue);
+        return 0;
     }
     return returnValue;
 }


### PR DESCRIPTION
Hi Thierry,

I've noticed an issue where if a JavaScript error occurs in a form on submit, the form still submits. This PR fixes it so that the form stays in draft mode until the error is fixed.

Cheers